### PR TITLE
add support for prebuild to build for all abi version of node/iojs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 npm-debug.log
 node_modules
 build
+prebuilds/

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Validate UTF-8 for Web",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Only testing builds, test have to be extraced from `ws`\" && exit 0"
+    "install": "prebuild --install",
+    "test": "echo \"Only testing builds, test have to be extraced from `ws`\" && exit 0",
+    "prebuild": "prebuild --all --strip"
   },
   "repository": {
     "type": "git",
@@ -21,6 +23,7 @@
   "homepage": "https://github.com/websockets/utf-8-validate",
   "dependencies": {
     "bindings": "1.2.x",
-    "nan": "^2.0.5"
+    "nan": "^2.0.5",
+    "prebuild": "^2.8.1"
   }
 }


### PR DESCRIPTION
![prebuild-utf-8-validate](https://cloud.githubusercontent.com/assets/308049/9718199/feacc0ec-5579-11e5-94b3-d871d9ed1180.png)

While I was at it, I created this PR as well since `ws` use this native module as well as `bufferutil`, see https://github.com/websockets/bufferutil/pull/12