### PR TITLE
Fix validation for ill-formed byte sequences

### DIFF
--- a/src/validation.cc
+++ b/src/validation.cc
@@ -50,14 +50,13 @@ static int isLegalUTF8(const uint8_t *source, const int length)
   case 5: if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return 0; */
   case 4: if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return 0;
   case 3: if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return 0;
-  case 2: if ((a = (*--srcptr)) > 0xBF) return 0;
+  case 2: if ((a = (*--srcptr)) > 0xBF || a < 0x80) return 0;
     switch (*source) {
       /* no fall-through in this inner switch */
       case 0xE0: if (a < 0xA0) return 0; break;
       case 0xED: if (a > 0x9F) return 0; break;
       case 0xF0: if (a < 0x90) return 0; break;
       case 0xF4: if (a > 0x8F) return 0; break;
-      default:   if (a < 0x80) return 0;
     }
 
   case 1: if (*source >= 0x80 && *source < 0xC2) return 0;


### PR DESCRIPTION
I think there are a few cases where `isValidUTF8` returns the wrong value.

Consider the following example:

```
var isValidUTF8 = require('utf-8-validate').Validation.isValidUTF8
var fs = require('fs')

var buffer1 = new Buffer([0xed, 0x7f, 0x80])
console.log(isValidUTF8(buffer1)) // true
fs.writeFileSync('buffer1.txt', buffer1)

var buffer2 = new Buffer([0xf4, 0x7f, 0x80, 0x80])
console.log(isValidUTF8(buffer2)) // true
fs.writeFileSync('buffer2.txt', buffer2)
```

Checking if the two files are UTF-8 encoded with iconv:
```
$ iconv -t UTF-8 buffer1.txt 
iconv: illegal input sequence at position 0
$ iconv -t UTF-8 buffer2.txt 
iconv: illegal input sequence at position 0
```

Reading the two files in python:
```
>>> with open('buffer1.txt', 'rb') as stream:
...     content = stream.read()
>>> content
b'\xed\x7f\x80'
>>> content.decode()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xed in position 0: invalid continuation byte

>>> with open('buffer2.txt', 'rb') as stream:
...     content = stream.read()
>>> content
b'\xf4\x7f\x80\x80'
>>> content.decode()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf4 in position 0: invalid continuation byte
```

According to the [Unicode standard(page 125, table 3-7)](http://www.unicode.org/versions/Unicode9.0.0/ch03.pdf) the two byte sequences in the example are ill-formed, because the second byte is invalid.

The second byte should be between `0x80...0x9f` in the first case, and between `0x80...0xbf` in the second case. I think `isValidUtf8` returns `true` because it does not check the lower limit `0x80` [in this switch](https://github.com/websockets/utf-8-validate/blob/master/src/validation.cc#L53-L61).






