### PR TITLE
Add working fallback implementation

### DIFF
--- a/fallback.js
+++ b/fallback.js
@@ -1,13 +1,71 @@
-'use strict';
-
 /*!
  * UTF-8 validate: UTF-8 validation for WebSockets.
  * Copyright(c) 2015 Einar Otto Stangvik <einaros@gmail.com>
  * MIT Licensed
  */
 
+'use strict';
+
 exports.Validation = {
-  isValidUTF8: function(buffer) {
+  /**
+   * Checks if a given buffer contains only correct UTF-8.
+   * Ported from https://www.cl.cam.ac.uk/%7Emgk25/ucs/utf8_check.c by
+   * Markus Kuhn.
+   *
+   * @param {Buffer} buf The buffer to check
+   * @return {Boolean} `true` if `buf` contains only correct UTF-8, else `false`
+   */
+  isValidUTF8: function (buf) {
+    if (!Buffer.isBuffer(buf)) {
+      throw new TypeError('First argument needs to be a buffer');
+    }
+
+    var len = buf.length;
+    var i = 0;
+
+    while (i < len) {
+      if (buf[i] < 0x80) { // 0xxxxxxx
+        i++;
+      } else if ((buf[i] & 0xe0) === 0xc0) { // 110xxxxx 10xxxxxx
+        if (
+          i + 1 === len ||
+          (buf[i + 1] & 0xc0) !== 0x80 ||
+          (buf[i] & 0xfe) === 0xc0 // overlong
+        ) {
+          return false;
+        } else {
+          i += 2;
+        }
+      } else if ((buf[i] & 0xf0) === 0xe0) { // 1110xxxx 10xxxxxx 10xxxxxx
+        if (
+          i + 2 >= len ||
+          (buf[i + 1] & 0xc0) !== 0x80 ||
+          (buf[i + 2] & 0xc0) !== 0x80 ||
+          buf[i] === 0xe0 && (buf[i + 1] & 0xe0) === 0x80 || // overlong
+          buf[i] === 0xed && (buf[i + 1] & 0xe0) === 0xa0    // surrogate (U+D800 - U+DFFF)
+        ) {
+          return false;
+        } else {
+          i += 3;
+        }
+      } else if ((buf[i] & 0xf8) === 0xf0) { // 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+        if (
+          i + 3 >= len ||
+          (buf[i + 1] & 0xc0) !== 0x80 ||
+          (buf[i + 2] & 0xc0) !== 0x80 ||
+          (buf[i + 3] & 0xc0) !== 0x80 ||
+          buf[i] === 0xf0 && (buf[i + 1] & 0xf0) === 0x80 || // overlong
+          buf[i] === 0xf4 && buf[i + 1] > 0x8f || buf[i] > 0xf4 // > U+10FFFF
+        ) {
+          return false;
+        } else {
+          i += 4;
+        }
+      } else {
+        return false;
+      }
+    }
+
     return true;
   }
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -51,7 +51,7 @@ describe('bindings', function () {
   });
 });
 
-describe.skip('fallback', function () {
+describe('fallback', function () {
   var Validation = require('../fallback').Validation;
 
   it('should throw an error if the first argument is not a buffer', function () {


### PR DESCRIPTION
This adds a working fallback implementation based on https://www.cl.cam.ac.uk/%7Emgk25/ucs/utf8_check.c.

The only difference is that non-Unicode positions (U+FFFE..U+FFFF) are accepted as they are also accepted in the current C++ implementation.

Performance is good. This is what I got from `ws` benchmarks.

C++ addon

```
5000 roundtrips of 16 KiB text data:	2.1s	37.22 MiB/s
1000 roundtrips of 128 KiB text data:	2.7s	46.12 MiB/s
100 roundtrips of 1 MiB text data:	2.6s	38.9 MiB/s
```

fallback

```
5000 roundtrips of 16 KiB text data:	1.7s	45.19 MiB/s
1000 roundtrips of 128 KiB text data:	2.2s	57.78 MiB/s
100 roundtrips of 1 MiB text data:	2.1s	48.72 MiB/s
```

I didn't test with bigger strings.