### PR TITLE
Export the `isValidUTF8` function directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
   - "7"
   - "6"
   - "4"
-  - "0.12"
 os:
   - osx
 matrix:
@@ -18,10 +17,6 @@ matrix:
       sudo: false
       dist: trusty
     - node_js: "4"
-      os: linux
-      sudo: false
-      dist: trusty
-    - node_js: "0.12"
       os: linux
       sudo: false
       dist: trusty

--- a/README.md
+++ b/README.md
@@ -4,41 +4,49 @@
 [![Build Status](https://travis-ci.org/websockets/utf-8-validate.svg?branch=master)](https://travis-ci.org/websockets/utf-8-validate)
 [![Windows Build](https://ci.appveyor.com/api/projects/status/github/websockets/utf-8-validate?branch=master&svg=true)](https://ci.appveyor.com/project/lpinca/utf-8-validate)
 
-WebSocket connections require extensive UTF-8 validation in order to conform to
-the specification. This was unfortunately not possible in JavaScript, hence the
-need for a binary addon.
-
-As the module consists of binary components, it should be used as
-`optionalDependency` so when installation fails, it doesn't halt the
-installation of your module. There are fallback files available in this
-repository. See `fallback.js` for the suggest fallback implementation if
-installation fails.
+Check if a buffer contains valid UTF-8 encoded text.
 
 ## Installation
 
 ```
-npm install utf-8-validate
+npm install utf-8-validate --save-optional
 ```
+
+The `--save-optional` flag tells npm to save the package in your package.json
+under the [`optionalDependencies`](https://docs.npmjs.com/files/package.json#optionaldependencies)
+key.
 
 ## API
 
-In all examples we assume that you've already required the mdoule as
-follows:
+The module exports a single function which takes one argument.
+
+### `isValidUTF8(buffer)`
+
+Checks whether a buffer contains valid UTF-8.
+
+#### Arguments
+
+- `buffer` - The buffer to check.
+
+#### Return value
+
+`true` if the buffer contains only correct UTF-8, else `false`.
+
+#### Exceptions
+
+Throws a `TypeError` exception if the first argument is not a buffer.
+
+#### Example
 
 ```js
 'use strict';
 
-var validation = require('utf-8-validate').Validation;
-```
+const isValidUTF8 = require('utf-8-validate');
 
-The module exposes 1 function:
+const buf = Buffer.from([0xf0, 0x90, 0x80, 0x80]);
 
-#### isValidUTF8
-
-Validate if the passed in buffer contains valid UTF-8 chars.
-
-```js
-validation.isValidUTF8(buffer);
+console.log(isValidUTF8(buf));
+// => true
 ```
 
 ## License

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ environment:
     - nodejs_version: "7"
     - nodejs_version: "6"
     - nodejs_version: "4"
-    - nodejs_version: "0.12"
 platform:
   - x86
   - x64
@@ -11,7 +10,6 @@ matrix:
   fast_finish: true
 install:
   - ps: Install-Product node $env:nodejs_version $env:platform
-  - if %nodejs_version% equ 0.12 npm -g install npm@latest
   - npm install
 test_script:
   - node --version

--- a/fallback.js
+++ b/fallback.js
@@ -6,66 +6,67 @@
 
 'use strict';
 
-exports.Validation = {
-  /**
-   * Checks if a given buffer contains only correct UTF-8.
-   * Ported from https://www.cl.cam.ac.uk/%7Emgk25/ucs/utf8_check.c by
-   * Markus Kuhn.
-   *
-   * @param {Buffer} buf The buffer to check
-   * @return {Boolean} `true` if `buf` contains only correct UTF-8, else `false`
-   */
-  isValidUTF8: function (buf) {
-    if (!Buffer.isBuffer(buf)) {
-      throw new TypeError('First argument needs to be a buffer');
-    }
-
-    var len = buf.length;
-    var i = 0;
-
-    while (i < len) {
-      if (buf[i] < 0x80) { // 0xxxxxxx
-        i++;
-      } else if ((buf[i] & 0xe0) === 0xc0) { // 110xxxxx 10xxxxxx
-        if (
-          i + 1 === len ||
-          (buf[i + 1] & 0xc0) !== 0x80 ||
-          (buf[i] & 0xfe) === 0xc0 // overlong
-        ) {
-          return false;
-        } else {
-          i += 2;
-        }
-      } else if ((buf[i] & 0xf0) === 0xe0) { // 1110xxxx 10xxxxxx 10xxxxxx
-        if (
-          i + 2 >= len ||
-          (buf[i + 1] & 0xc0) !== 0x80 ||
-          (buf[i + 2] & 0xc0) !== 0x80 ||
-          buf[i] === 0xe0 && (buf[i + 1] & 0xe0) === 0x80 || // overlong
-          buf[i] === 0xed && (buf[i + 1] & 0xe0) === 0xa0    // surrogate (U+D800 - U+DFFF)
-        ) {
-          return false;
-        } else {
-          i += 3;
-        }
-      } else if ((buf[i] & 0xf8) === 0xf0) { // 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
-        if (
-          i + 3 >= len ||
-          (buf[i + 1] & 0xc0) !== 0x80 ||
-          (buf[i + 2] & 0xc0) !== 0x80 ||
-          (buf[i + 3] & 0xc0) !== 0x80 ||
-          buf[i] === 0xf0 && (buf[i + 1] & 0xf0) === 0x80 || // overlong
-          buf[i] === 0xf4 && buf[i + 1] > 0x8f || buf[i] > 0xf4 // > U+10FFFF
-        ) {
-          return false;
-        } else {
-          i += 4;
-        }
-      } else {
-        return false;
-      }
-    }
-
-    return true;
+/**
+ * Checks if a given buffer contains only correct UTF-8.
+ * Ported from https://www.cl.cam.ac.uk/%7Emgk25/ucs/utf8_check.c by
+ * Markus Kuhn.
+ *
+ * @param {Buffer} buf The buffer to check
+ * @return {Boolean} `true` if `buf` contains only correct UTF-8, else `false`
+ * @public
+ */
+const isValidUTF8 = (buf) => {
+  if (!Buffer.isBuffer(buf)) {
+    throw new TypeError('First argument needs to be a buffer');
   }
+
+  var len = buf.length;
+  var i = 0;
+
+  while (i < len) {
+    if (buf[i] < 0x80) {  // 0xxxxxxx
+      i++;
+    } else if ((buf[i] & 0xe0) === 0xc0) {  // 110xxxxx 10xxxxxx
+      if (
+        i + 1 === len ||
+        (buf[i + 1] & 0xc0) !== 0x80 ||
+        (buf[i] & 0xfe) === 0xc0  // overlong
+      ) {
+        return false;
+      } else {
+        i += 2;
+      }
+    } else if ((buf[i] & 0xf0) === 0xe0) {  // 1110xxxx 10xxxxxx 10xxxxxx
+      if (
+        i + 2 >= len ||
+        (buf[i + 1] & 0xc0) !== 0x80 ||
+        (buf[i + 2] & 0xc0) !== 0x80 ||
+        buf[i] === 0xe0 && (buf[i + 1] & 0xe0) === 0x80 ||  // overlong
+        buf[i] === 0xed && (buf[i + 1] & 0xe0) === 0xa0     // surrogate (U+D800 - U+DFFF)
+      ) {
+        return false;
+      } else {
+        i += 3;
+      }
+    } else if ((buf[i] & 0xf8) === 0xf0) {  // 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+      if (
+        i + 3 >= len ||
+        (buf[i + 1] & 0xc0) !== 0x80 ||
+        (buf[i + 2] & 0xc0) !== 0x80 ||
+        (buf[i + 3] & 0xc0) !== 0x80 ||
+        buf[i] === 0xf0 && (buf[i + 1] & 0xf0) === 0x80 ||  // overlong
+        buf[i] === 0xf4 && buf[i + 1] > 0x8f || buf[i] > 0xf4  // > U+10FFFF
+      ) {
+        return false;
+      } else {
+        i += 4;
+      }
+    } else {
+      return false;
+    }
+  }
+
+  return true;
 };
+
+module.exports = isValidUTF8;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "utf-8-validate",
   "version": "2.0.0",
-  "description": "Validate UTF-8 for Web",
+  "description": "Check if a buffer contains valid UTF-8",
   "main": "index.js",
   "scripts": {
     "coverage": "istanbul cover _mocha --report html -- test/*.test.js",

--- a/src/validation.cc
+++ b/src/validation.cc
@@ -4,110 +4,73 @@
  * MIT Licensed
  */
 
-#include <v8.h>
-#include <node.h>
-#include <node_version.h>
-#include <node_buffer.h>
-#include <node_object_wrap.h>
-#include <stdlib.h>
-#include <wchar.h>
-#include <stdio.h>
-#include "nan.h"
+#include <nan.h>
 
-using namespace v8;
-using namespace node;
-
-class Validation : public ObjectWrap {
-public:
-  static void Initialize(v8::Handle<v8::Object> target) {
-    Nan::HandleScope scope;
-    Local<FunctionTemplate> t = Nan::New<FunctionTemplate>(New);
-    t->InstanceTemplate()->SetInternalFieldCount(1);
-    Nan::SetMethod(t, "isValidUTF8", Validation::IsValidUTF8);
-    Nan::Set(target, Nan::New<String>("Validation").ToLocalChecked(),
-             t->GetFunction());
+NAN_METHOD(isValidUTF8) {
+  if (!node::Buffer::HasInstance(info[0])) {
+    Nan::ThrowTypeError("First argument needs to be a buffer");
+    return;
   }
 
-protected:
-  static NAN_METHOD(New) {
-    Nan::HandleScope scope;
-    Validation* validation = new Validation();
-    validation->Wrap(info.This());
-    info.GetReturnValue().Set(info.This());
-  }
+  uint8_t* s = reinterpret_cast<uint8_t*>(node::Buffer::Data(info[0]));
+  size_t length = node::Buffer::Length(info[0]);
+  uint8_t* end = s + length;
 
-  static NAN_METHOD(IsValidUTF8) {
-    Nan::HandleScope scope;
-    if (!Buffer::HasInstance(info[0])) {
-      return Nan::ThrowTypeError("First argument needs to be a buffer");
-    }
-
-    Local<Object> buffer = info[0]->ToObject();
-    uint8_t *s = (uint8_t *) Buffer::Data(buffer);
-    size_t length = Buffer::Length(buffer);
-    uint8_t *end = s + length;
-
-    //
-    // This code has been taken from utf8_check.c which was developed by
-    // Markus Kuhn <http://www.cl.cam.ac.uk/~mgk25/>.
-    //
-    // For original code / licensing please refer to
-    // https://www.cl.cam.ac.uk/%7Emgk25/ucs/utf8_check.c
-    //
-    while (s < end) {
-      if (*s < 0x80) { // 0xxxxxxx
-        s++;
-      } else if ((s[0] & 0xe0) == 0xc0) { // 110xxxxx 10xxxxxx
-        if (
-          s + 1 == end ||
-          (s[1] & 0xc0) != 0x80 ||
-          (s[0] & 0xfe) == 0xc0 // overlong
-        ) {
-          break;
-        } else {
-          s += 2;
-        }
-      } else if ((s[0] & 0xf0) == 0xe0) { // 1110xxxx 10xxxxxx 10xxxxxx
-        if (
-          s + 2 >= end ||
-          (s[1] & 0xc0) != 0x80 ||
-          (s[2] & 0xc0) != 0x80 ||
-          (s[0] == 0xe0 && (s[1] & 0xe0) == 0x80) ||
-          (s[0] == 0xed && (s[1] & 0xe0) == 0xa0)
-        ) {
-          break;
-        } else {
-          s += 3;
-        }
-      } else if ((s[0] & 0xf8) == 0xf0) { // 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
-        if (
-          s + 3 >= end ||
-          (s[1] & 0xc0) != 0x80 ||
-          (s[2] & 0xc0) != 0x80 ||
-          (s[3] & 0xc0) != 0x80 ||
-          (s[0] == 0xf0 && (s[1] & 0xf0) == 0x80) || // overlong
-          (s[0] == 0xf4 && s[1] > 0x8f) || s[0] > 0xf4 // > U+10FFFF
-        ) {
-          break;
-        } else {
-          s += 4;
-        }
-      } else {
+  //
+  // This code has been taken from utf8_check.c which was developed by
+  // Markus Kuhn <http://www.cl.cam.ac.uk/~mgk25/>.
+  //
+  // For original code / licensing please refer to
+  // https://www.cl.cam.ac.uk/%7Emgk25/ucs/utf8_check.c
+  //
+  while (s < end) {
+    if (*s < 0x80) {  // 0xxxxxxx
+      s++;
+    } else if ((s[0] & 0xe0) == 0xc0) {  // 110xxxxx 10xxxxxx
+      if (
+        s + 1 == end ||
+        (s[1] & 0xc0) != 0x80 ||
+        (s[0] & 0xfe) == 0xc0  // overlong
+      ) {
         break;
+      } else {
+        s += 2;
       }
+    } else if ((s[0] & 0xf0) == 0xe0) {  // 1110xxxx 10xxxxxx 10xxxxxx
+      if (
+        s + 2 >= end ||
+        (s[1] & 0xc0) != 0x80 ||
+        (s[2] & 0xc0) != 0x80 ||
+        (s[0] == 0xe0 && (s[1] & 0xe0) == 0x80) ||
+        (s[0] == 0xed && (s[1] & 0xe0) == 0xa0)
+      ) {
+        break;
+      } else {
+        s += 3;
+      }
+    } else if ((s[0] & 0xf8) == 0xf0) {  // 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+      if (
+        s + 3 >= end ||
+        (s[1] & 0xc0) != 0x80 ||
+        (s[2] & 0xc0) != 0x80 ||
+        (s[3] & 0xc0) != 0x80 ||
+        (s[0] == 0xf0 && (s[1] & 0xf0) == 0x80) ||  // overlong
+        (s[0] == 0xf4 && s[1] > 0x8f) || s[0] > 0xf4  // > U+10FFFF
+      ) {
+        break;
+      } else {
+        s += 4;
+      }
+    } else {
+      break;
     }
-
-    info.GetReturnValue().Set(s < end ? Nan::False() : Nan::True());
   }
-};
 
-#if !NODE_VERSION_AT_LEAST(0,10,0)
-extern "C"
-#endif
+  info.GetReturnValue().Set(Nan::New<v8::Boolean>(s == end));
+}
 
-void init(Handle<Object> target) {
-  Nan::HandleScope scope;
-  Validation::Initialize(target);
+void init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
+  Nan::SetMethod(module, "exports", isValidUTF8);
 }
 
 NODE_MODULE(validation, init)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,96 +1,98 @@
 'use strict';
 
-var assert = require('assert');
-var path = require('path');
-var fs = require('fs');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
 
-var txt = fs.readFileSync(path.join(__dirname, 'fixtures', 'lorem-ipsum.txt'));
+const txt = fs.readFileSync(path.join(__dirname, 'fixtures', 'lorem-ipsum.txt'));
 
 describe('bindings', function () {
-  var Validation = require('bindings')('validation').Validation;
+  const isValidUTF8 = require('bindings')('validation');
 
   it('should throw an error if the first argument is not a buffer', function () {
-    assert.throws(function () {
-      Validation.isValidUTF8({});
-    }, /TypeError: First argument needs to be a buffer/);
+    assert.throws(
+      () => isValidUTF8({}),
+      /TypeError: First argument needs to be a buffer/
+    );
   });
 
   it('should return true with an empty buffer', function () {
-    assert.strictEqual(Validation.isValidUTF8(new Buffer(0)), true);
+    assert.strictEqual(isValidUTF8(Buffer.alloc(0)), true);
   });
 
   it('should return true for a valid utf8 string', function () {
-    assert.strictEqual(Validation.isValidUTF8(new Buffer(txt)), true);
+    assert.strictEqual(isValidUTF8(Buffer.from(txt)), true);
   });
 
   it('should return false for an erroneous string', function () {
-    var invalid = new Buffer([
+    var invalid = Buffer.from([
       0xce, 0xba, 0xe1, 0xbd, 0xb9, 0xcf, 0x83, 0xce, 0xbc, 0xce, 0xb5, 0xed,
       0xa0, 0x80, 0x65, 0x64, 0x69, 0x74, 0x65, 0x64
     ]);
 
-    assert.strictEqual(Validation.isValidUTF8(invalid), false);
+    assert.strictEqual(isValidUTF8(invalid), false);
   });
 
   it('should return true for valid cases from the autobahn test suite', function () {
     assert.strictEqual(
-      Validation.isValidUTF8(new Buffer('\xf0\x90\x80\x80')),
+      isValidUTF8(Buffer.from('\xf0\x90\x80\x80')),
       true
     );
     assert.strictEqual(
-      Validation.isValidUTF8(new Buffer([0xf0, 0x90, 0x80, 0x80])),
+      isValidUTF8(Buffer.from([0xf0, 0x90, 0x80, 0x80])),
       true
     );
   });
 
   it('should return false for erroneous autobahn strings', function () {
     assert.strictEqual(
-      Validation.isValidUTF8(new Buffer([0xce, 0xba, 0xe1, 0xbd])),
+      isValidUTF8(Buffer.from([0xce, 0xba, 0xe1, 0xbd])),
       false
     );
   });
 });
 
 describe('fallback', function () {
-  var Validation = require('../fallback').Validation;
+  var isValidUTF8 = require('../fallback');
 
   it('should throw an error if the first argument is not a buffer', function () {
-    assert.throws(function () {
-      Validation.isValidUTF8({});
-    }, /TypeError: First argument needs to be a buffer/);
+    assert.throws(
+      () => isValidUTF8({}),
+      /TypeError: First argument needs to be a buffer/
+    );
   });
 
   it('should return true with an empty buffer', function () {
-    assert.strictEqual(Validation.isValidUTF8(new Buffer(0)), true);
+    assert.strictEqual(isValidUTF8(Buffer.alloc(0)), true);
   });
 
   it('should return true for a valid utf8 string', function () {
-    assert.strictEqual(Validation.isValidUTF8(new Buffer(txt)), true);
+    assert.strictEqual(isValidUTF8(Buffer.from(txt)), true);
   });
 
   it('should return false for an erroneous string', function () {
-    var invalid = new Buffer([
+    var invalid = Buffer.from([
       0xce, 0xba, 0xe1, 0xbd, 0xb9, 0xcf, 0x83, 0xce, 0xbc, 0xce, 0xb5, 0xed,
       0xa0, 0x80, 0x65, 0x64, 0x69, 0x74, 0x65, 0x64
     ]);
 
-    assert.strictEqual(Validation.isValidUTF8(invalid), false);
+    assert.strictEqual(isValidUTF8(invalid), false);
   });
 
   it('should return true for valid cases from the autobahn test suite', function () {
     assert.strictEqual(
-      Validation.isValidUTF8(new Buffer('\xf0\x90\x80\x80')),
+      isValidUTF8(Buffer.from('\xf0\x90\x80\x80')),
       true
     );
     assert.strictEqual(
-      Validation.isValidUTF8(new Buffer([0xf0, 0x90, 0x80, 0x80])),
+      isValidUTF8(Buffer.from([0xf0, 0x90, 0x80, 0x80])),
       true
     );
   });
 
   it('should return false for erroneous autobahn strings', function () {
     assert.strictEqual(
-      Validation.isValidUTF8(new Buffer([0xce, 0xba, 0xe1, 0xbd])),
+      isValidUTF8(Buffer.from([0xce, 0xba, 0xe1, 0xbd])),
       false
     );
   });


### PR DESCRIPTION
This simplifies the C++ code and changes how the `isValidUTF8` function is exported.