### PR TITLE
Port to N-API

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,13 +2,15 @@
   'targets': [
     {
       'target_name': 'validation',
-      'include_dirs': ["<!(node -e \"require('nan')\")"],
-      'sources': [ 'src/validation.cc' ],
-      'xcode_settings': {
-        'MACOSX_DEPLOYMENT_TARGET': '10.8',
+      'xcode_settings': { 
+        'CLANG_CXX_LIBRARY': 'libc++',
         'CLANG_CXX_LANGUAGE_STANDARD': 'c++11',
-        'CLANG_CXX_LIBRARY': 'libc++'
-      }
+        'MACOSX_DEPLOYMENT_TARGET': '10.8'
+      },
+      'include_dirs': ['<!@(node -p "require(\'node-addon-api\').include")'],
+      'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
+      'defines': ['NAPI_DISABLE_CPP_EXCEPTIONS'],
+      'sources': [ 'src/validation.cc' ]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "homepage": "https://github.com/websockets/utf-8-validate",
   "dependencies": {
+    "node-addon-api": "~1.1.0",
     "bindings": "~1.3.0",
-    "nan": "~2.8.0",
     "prebuild-install": "~2.3.0"
   },
   "devDependencies": {

--- a/src/validation.cc
+++ b/src/validation.cc
@@ -4,11 +4,14 @@
  * MIT Licensed
  */
 
-#include <nan.h>
+#include <napi.h>
 
-NAN_METHOD(isValidUTF8) {
-  uint8_t* s = reinterpret_cast<uint8_t*>(node::Buffer::Data(info[0]));
-  size_t length = node::Buffer::Length(info[0]);
+static Napi::Value isValidUTF8(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  Napi::Buffer<char> buf = info[0].As<Napi::Buffer<char>>();
+  uint8_t* s = reinterpret_cast<uint8_t*>(buf.Data());
+  size_t length = buf.Length();
   uint8_t* end = s + length;
 
   //
@@ -61,11 +64,11 @@ NAN_METHOD(isValidUTF8) {
     }
   }
 
-  info.GetReturnValue().Set(Nan::New<v8::Boolean>(s == end));
+  return Napi::Boolean::New(env, s == end);
 }
 
-void init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
-  Nan::SetMethod(module, "exports", isValidUTF8);
+static Napi::Object init(Napi::Env env, Napi::Object exports) {
+  return Napi::Function::New(env, &isValidUTF8);
 }
 
-NODE_MODULE(validation, init)
+NODE_API_MODULE(validation, init)


### PR DESCRIPTION
 - removed nan dependency
 - add node-addon-api dependency
 - port validation.cc to N-API
 - ~add test case for no argument given~

Since node 8 there is a new experimental feature called N-API which is aimed at reducing maintenance cost for node native addons. Checkout this [blog](https://medium.com/the-node-js-collection/n-api-next-generation-node-js-apis-for-native-modules-169af5235b06)/[talk](https://www.youtube.com/watch?v=E848bgHfoxE) for more details on its benefits. 

Edit:
utf-8-validate is one of the top 35 native modules by dependency count. I used this native module first as playground to get my hands on N-API. The port to N-API is now working pretty good so I like to share this code. This should not be merged into master. N-API is still a experimental feature. It would be useful to have a napi branch. The [work group](https://github.com/nodejs/abi-stable-node) is asking for feedback from productive running systems. It would be nice if this branch could be published to npm registry. [Here](https://nodejs.org/en/docs/guides/publishing-napi-modules/) is a guide on how to do that. But its up to you if you want to support this feature in experimental state.