### PR TITLE
[ci] Prebuild linux/arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         arch:
           - x64
           - x86
+          - arm64
         node:
           - 14
           - 16
@@ -26,8 +27,12 @@ jobs:
         exclude:
           - arch: x86
             os: macos-latest
+          - arch: arm64
+            os: macos-latest
           - arch: x86
             os: ubuntu-latest
+          - arch: arm64
+            os: windows-latest
           - arch: x86
             node: 18
             os: windows-latest
@@ -48,6 +53,7 @@ jobs:
         arch:
           - x64
           - x86
+          - arm64
         os:
           - macos-latest
           - ubuntu-18.04
@@ -55,8 +61,12 @@ jobs:
         exclude:
           - arch: x86
             os: macos-latest
+          - arch: arm64
+            os: macos-latest
           - arch: x86
             os: ubuntu-18.04
+          - arch: arm64
+            os: windows-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -91,6 +101,9 @@ jobs:
       - run:
           tar -cvf "${{ steps.get_version.outputs.version }}-linux-x64.tar" -C
           "prebuilds/ubuntu-18.04" linux-x64
+      - run:
+          tar -cvf "${{ steps.get_version.outputs.version }}-linux-arm64.tar" -C
+          "prebuilds/ubuntu-18.04" linux-arm64
       - run:
           tar -cvf "${{ steps.get_version.outputs.version }}-win32-ia32.tar" -C
           "prebuilds/windows-latest" win32-ia32


### PR DESCRIPTION
Hi @lpinca, we would like to use the library in our application, but the install fails due to the missing prebuild. Could you add the `linux/arm64` platform to support cloud platforms like AWS Graviton 🙏 

Feel free to update the PR or create a new one if you want to do it differently 😄 