### PR TITLE
[pkg] Add dual CJS/ESM support with bundler compatibility

### DIFF
--- a/fallback.mjs
+++ b/fallback.mjs
@@ -1,0 +1,3 @@
+import isValidUTF8 from './fallback.js';
+
+export default isValidUTF8;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export default function isValidUTF8(buffer: Buffer): boolean;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,26 @@
 'use strict';
 
+const { load } = require('node-gyp-build-esm');
+
+let binding;
+
 try {
-  module.exports = require('node-gyp-build')(__dirname);
-} catch (e) {
-  module.exports = require('./fallback');
+  binding = load(__dirname, () => ({
+    'darwin-arm64': () =>
+      require(
+        /* @vite-ignore */ './prebuilds/darwin-arm64/utf-8-validate.node',
+      ),
+    'darwin-x64': () =>
+      require(/* @vite-ignore */ './prebuilds/darwin-x64/utf-8-validate.node'),
+    'linux-x64': () =>
+      require(/* @vite-ignore */ './prebuilds/linux-x64/utf-8-validate.node'),
+    'win32-ia32': () =>
+      require(/* @vite-ignore */ './prebuilds/win32-ia32/utf-8-validate.node'),
+    'win32-x64': () =>
+      require(/* @vite-ignore */ './prebuilds/win32-x64/utf-8-validate.node'),
+  }));
+} catch {
+  binding = require('./fallback.js');
 }
+
+module.exports = binding;

--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,110 @@
+import { load } from 'node-gyp-build-esm';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+
+import isValidUTF8 from './fallback.mjs';
+
+let binding;
+
+// In a CJS bundle (esbuild/webpack), `require` is defined — esbuild replaces it
+// with its own `__require` implementation, webpack with `__webpack_require__`.
+// In a pure ESM environment (no bundler), `require` is undefined, so we fall back
+// to `createRequire(import.meta.url)` which provides a CJS-style require anchored
+// to the current module's path.
+// Note: native .node addons cannot be loaded via ESM `import()` because
+// `process.dlopen` is synchronous — `require` or `createRequire` is always needed.
+//
+// IMPORTANT: The `if/else` structure is intentional and must not be refactored
+// into a ternary or other expression. Bundlers like esbuild and webpack statically
+// analyze `typeof require === 'function'` as a known condition at build time,
+// allowing them to tree-shake the `else` branch entirely. Collapsing this into
+// an expression (e.g. `const _require = typeof require === 'function' ? require : ...`)
+// breaks that static analyzability.
+try {
+  if (typeof require === 'function') {
+    const isVite =
+      typeof import.meta !== 'undefined' &&
+      !!import.meta.env?.MODE &&
+      !!import.meta.env.BASE_URL;
+
+    if (isVite) {
+      binding = load(import.meta.dirname, () => ({
+        'darwin-arm64': () =>
+          require(
+            join(
+              process.cwd(),
+              'node_modules/utf-8-validate/prebuilds/darwin-arm64/utf-8-validate.node',
+            ),
+          ),
+        'darwin-x64': () =>
+          require(
+            join(
+              process.cwd(),
+              'node_modules/utf-8-validate/prebuilds/darwin-x64/utf-8-validate.node',
+            ),
+          ),
+        'linux-x64': () =>
+          require(
+            join(
+              process.cwd(),
+              'node_modules/utf-8-validate/prebuilds/linux-x64/utf-8-validate.node',
+            ),
+          ),
+        'win32-ia32': () =>
+          require(
+            join(
+              process.cwd(),
+              'node_modules/utf-8-validate/prebuilds/win32-ia32/utf-8-validate.node',
+            ),
+          ),
+        'win32-x64': () =>
+          require(
+            join(
+              process.cwd(),
+              'node_modules/utf-8-validate/prebuilds/win32-x64/utf-8-validate.node',
+            ),
+          ),
+      }));
+    } else {
+      binding = load(import.meta.dirname, () => ({
+        'darwin-arm64': () =>
+          require(
+            /* @vite-ignore */ './prebuilds/darwin-arm64/utf-8-validate.node',
+          ),
+        'darwin-x64': () =>
+          require(
+            /* @vite-ignore */ './prebuilds/darwin-x64/utf-8-validate.node',
+          ),
+        'linux-x64': () =>
+          require(
+            /* @vite-ignore */ './prebuilds/linux-x64/utf-8-validate.node',
+          ),
+        'win32-ia32': () =>
+          require(
+            /* @vite-ignore */ './prebuilds/win32-ia32/utf-8-validate.node',
+          ),
+        'win32-x64': () =>
+          require(
+            /* @vite-ignore */ './prebuilds/win32-x64/utf-8-validate.node',
+          ),
+      }));
+    }
+  } else {
+    // `require` is block-scoped here intentionally — it avoids a duplicate
+    // binding conflict with any `require` that a bundler may inject globally.
+    const require = createRequire(import.meta.url);
+
+    binding = load(import.meta.dirname, () => ({
+      'darwin-arm64': () =>
+        require('./prebuilds/darwin-arm64/utf-8-validate.node'),
+      'darwin-x64': () => require('./prebuilds/darwin-x64/utf-8-validate.node'),
+      'linux-x64': () => require('./prebuilds/linux-x64/utf-8-validate.node'),
+      'win32-ia32': () => require('./prebuilds/win32-ia32/utf-8-validate.node'),
+      'win32-x64': () => require('./prebuilds/win32-x64/utf-8-validate.node'),
+    }));
+  }
+} catch {
+  binding = isValidUTF8;
+}
+
+export default binding;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,24 @@
   "name": "utf-8-validate",
   "version": "6.0.6",
   "description": "Check if a buffer contains valid UTF-8",
-  "main": "index.js",
+  "main": "./index.cjs",
+  "module": "./index.mjs",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      }
+    },
+    "./package.json": {
+      "default": "./package.json"
+    }
+  },
+  "typings": "./index.d.ts",
   "engines": {
     "node": ">=6.14.2"
   },
@@ -20,7 +37,10 @@
     "deps/is_utf8/src/is_utf8.cpp",
     "binding.gyp",
     "fallback.js",
-    "index.js"
+    "fallback.mjs",
+    "index.js",
+    "index.mjs",
+    "index.d.ts"
   ],
   "repository": {
     "type": "git",
@@ -36,7 +56,7 @@
   },
   "homepage": "https://github.com/websockets/utf-8-validate",
   "dependencies": {
-    "node-gyp-build": "^4.3.0"
+    "node-gyp-build-esm": "^5.0.2"
   },
   "devDependencies": {
     "mocha": "^11.0.1",

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,9 @@ const { join } = require('path');
 const { readFileSync } = require('fs');
 const { strictEqual } = require('assert');
 
+const isValidUTF8 = require('../index.js');
+const isValidUTF8Fallback = require('../fallback.js');
+
 const txt = readFileSync(join(__dirname, 'fixtures', 'lorem-ipsum.txt'));
 
 function use(isValidUTF8) {
@@ -19,31 +22,22 @@ function use(isValidUTF8) {
     it('returns false for an erroneous string', function () {
       var invalid = Buffer.from([
         0xce, 0xba, 0xe1, 0xbd, 0xb9, 0xcf, 0x83, 0xce, 0xbc, 0xce, 0xb5, 0xed,
-        0xa0, 0x80, 0x65, 0x64, 0x69, 0x74, 0x65, 0x64
+        0xa0, 0x80, 0x65, 0x64, 0x69, 0x74, 0x65, 0x64,
       ]);
 
       strictEqual(isValidUTF8(invalid), false);
     });
 
     it('returns true for valid cases from the autobahn test suite', function () {
-      strictEqual(
-        isValidUTF8(Buffer.from('\xf0\x90\x80\x80')),
-        true
-      );
-      strictEqual(
-        isValidUTF8(Buffer.from([0xf0, 0x90, 0x80, 0x80])),
-        true
-      );
+      strictEqual(isValidUTF8(Buffer.from('\xf0\x90\x80\x80')), true);
+      strictEqual(isValidUTF8(Buffer.from([0xf0, 0x90, 0x80, 0x80])), true);
     });
 
     it('returns false for erroneous autobahn strings', function () {
-      strictEqual(
-        isValidUTF8(Buffer.from([0xce, 0xba, 0xe1, 0xbd])),
-        false
-      );
+      strictEqual(isValidUTF8(Buffer.from([0xce, 0xba, 0xe1, 0xbd])), false);
     });
   };
 }
 
-describe('bindings', use(require('node-gyp-build')(join(__dirname, '..'))));
-describe('fallback', use(require('../fallback')));
+describe('bindings', use(isValidUTF8));
+describe('fallback', use(isValidUTF8Fallback));


### PR DESCRIPTION
Replace node-gyp-build with node-gyp-build-esm and introduce a proper dual CJS/ESM package setup.

- Add index.mjs as the ESM entry point with explicit per-platform prebuild loaders and @vite-ignore comments for bundler compatibility
- Add fallback.mjs as a thin ESM wrapper around the CJS fallback module
- Add index.d.ts with TypeScript type definitions
- Update package.json with a conditional exports map (import/require), a "module" field, "typings", and updated "files" list
- Add Vite detection in index.mjs to resolve prebuilds from process.cwd() when running under Vite, since import.meta.dirname is not usable there
- Update index.js to use node-gyp-build-esm's load() with per-platform loaders for consistency with the ESM entry point
- Update tests to import via the package entry points rather than calling node-gyp-build directly